### PR TITLE
Fix crash on undefined macro + update bin/ccss

### DIFF
--- a/bin/ccss
+++ b/bin/ccss
@@ -9,15 +9,15 @@ from clevercss.errors import *
 
 help_text = '''
 usage: %prog <file 1> ... <file n>
-  if called with some filenames it will read each file, cut of
-  the extension and append a ".css" extension and save. If 
-  the target file has the same name as the source file it will
-  abort, but if it overrides a file during this process it will
-  continue. This is a desired functionality. To avoid that you
-  must not give your source file a .css extension.
+if called with some filenames it will read each file, cut of
+the extension and append a ".css" extension and save. If
+the target file has the same name as the source file it will
+abort, but if it overrides a file during this process it will
+continue. This is a desired functionality. To avoid that you
+must not give your source file a .css extension.
 
-  if you call it without arguments it will read from stdin and
-  write the converted css to stdout.
+if you call it without arguments it will read from stdin and
+write the converted css to stdout.
 '''
 
 version_text = '''\
@@ -31,7 +31,7 @@ def main():
     parser.add_option('--eigen-test', action='store_true',
             help='evaluate the example from the docstring')
     parser.add_option('--list-colors', action='store_true',
-            help='list all known coor names')
+            help='list all known color names')
     parser.add_option('-n', '--no-overwrite', action='store_true', dest='no_overwrite',
             help='don\'t overwrite any files (default=false)')
     parser.add_option('--to-ccss', action='store_true',
@@ -74,13 +74,13 @@ def parseCSS(text):
     return rules
 
 def rulesToCCSS(selector, rules):
-    text = selector + ':\n  '
+    text = selector + ':\n '
     if rules.get(':rules:'):
-        text += '\n\n  '.join('\n  '.join(line.strip().rstrip(';') for line in rule.style.cssText.splitlines()) for rule in rules.get(':rules:', [])) + '\n'
+        text += '\n\n '.join('\n '.join(line.strip().rstrip(';') for line in rule.style.cssText.splitlines()) for rule in rules.get(':rules:', [])) + '\n'
     for other in rules:
         if other == ':rules:':
             continue
-        text += '\n  ' + rulesToCCSS(other, rules[other]).replace('\n', '\n  ')
+        text += '\n ' + rulesToCCSS(other, rules[other]).replace('\n', '\n ')
     return text
 
 def cleverfy(fname):
@@ -99,7 +99,7 @@ def do_test():
 def list_colors():
     print '%d known colors:' % len(clevercss.consts.COLORS)
     for color in sorted(clevercss.consts.COLORS.items()):
-        print '  %-30s%s' % color
+        print ' %-30s%s' % color
 
 def convert_stream():
     import sys
@@ -127,6 +127,10 @@ def convert_many(files, options):
             except (ParserError, EvalException), e:
                 sys.stderr.write('Error in file %s: %s\n' % (fname, e))
                 sys.exit(1)
+            if options.minified:
+                css = cssutils.CSSParser().parseString(converted)
+                cssutils.ser.prefs.useMinified()
+                converted = css.cssText
             dst = open(target, 'w')
             try:
                 print 'Writing output to %s...' % target

--- a/clevercss/engine.py
+++ b/clevercss/engine.py
@@ -34,7 +34,7 @@ class Engine(object):
         expr = None
         if context is None:
             context = {}
-        elif not isinstance(context, dict): 
+        elif not isinstance(context, dict):
             raise TypeError("context argument must be a dictionary")
 
         for key, value in context.iteritems():
@@ -238,7 +238,7 @@ class Parser(object):
                 # new rule blocks
                 elif line.endswith(','):
                     sub_rules.append(line)
-                                
+
                 elif line.endswith(':'):
                     sub_rules.append(line[:-1].rstrip())
                     s_rule = ' '.join(sub_rules)
@@ -323,7 +323,7 @@ class Parser(object):
                         if k == '__macros_call__':
                             macros_defs = macroses.get(v, None)
                             if macros_defs is None:
-                                fail('No macros with name "%s" is defined' % v)
+                                raise ParserError(lineno, 'No macro with name "%s" is defined' % v)
                             styles.extend(expand_defs(macros_defs))
                         else:
                             styles.append(expand_def((lineno, k, v)))

--- a/tests/ccss_to_css.py
+++ b/tests/ccss_to_css.py
@@ -10,6 +10,8 @@ import clevercss
 from clevercss import convert
 from clevercss.line_iterator import LineIterator
 
+from clevercss.errors import *
+
 def eigen_test():
     filename = os.path.join(os.path.dirname(__file__), 'eigentest.ccss')
     ccss = open(filename).read()
@@ -17,11 +19,11 @@ def eigen_test():
 
 class ConvertTestCase(TestCase):
     def convert(self):
-        self.assertEqual(convert('''body: 
-            color: $color 
+        self.assertEqual(convert('''body:
+            color: $color
         ''',{'color':'#eee'}),
         u'body {\n  color: #eeeeee;\n}')
-    
+
     def convert2(self):
         self.assertEqual(convert('''body:
             background-color: $background_color
@@ -122,7 +124,7 @@ class ConvertTestCase(TestCase):
       """
       self.assertEqual(convert(dedent("""
       @import url(tests/example.ccss)
-      
+
       div:
           color: $arg
       """)), dedent("""
@@ -137,11 +139,11 @@ class ConvertTestCase(TestCase):
       #test3 {
         color: blue;
       }
-      
+
       div {
         color: blue;
       }""").strip())
-      
+
 
     def test_multiline_rule(self):
         self.assertEqual(convert(dedent("""
@@ -191,21 +193,31 @@ class MacroTestCase(TestCase):
         }''')
         self.assertEqual(convert(ccss), css)
 
+    def test_undefined_macro(self):
+        ccss = dedent('''
+        body:
+            $simple
+            width:200px
+        .other:
+            $simple
+        ''')
+        self.assertRaises(ParserError, convert, ccss)
+
 class LineIterTestCase(TestCase):
     def test_comments(self):
         line_iter = LineIterator(dedent(
         """
         /* block */
-        /* multiblock 
+        /* multiblock
         */
-                
-        aa, /* comment */bb: 
+
+        aa, /* comment */bb:
             x:1 // comment
-            
+
         """))
         self.assertEqual("\n".join([s[1] for s in line_iter]),
             "aa, bb:\n    x:1")
-    
+
 
 def all_tests():
     return unittest.TestSuite(case.toSuite() for case in [ConvertTestCase, LineIterTestCase, MacroTestCase])


### PR DESCRIPTION
1. When the parser encounters an undefined macro, it tried to call the 'fail' function which is not in scope at that point. This results in an unhandled exception being thrown and the program crashes. This has been fixed by raising ParserError directly rather than calling the 'fail' convenience function. While it is possible to define a fail function in that scope, this seems cleaner for now.
2. The bin/ccss script seemed to be an older version as compared to the clevercss/ccss.py script. The bin/ccss script has been made identical to clevercss/ccss.py.
